### PR TITLE
MMG and Firetext API stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binaries for programs and plugins
+bin/
 *.exe
 *.exe~
 *.dll

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,31 @@
+SHELL := /bin/bash
+
 .PHONY: build
 build:
 	go build -o bin/sms-provider-stub
 
+.PHONY: run
 run: build
 	./bin/sms-provider-stub
+
+.PHONY: preview
+preview:
+	$(eval export CF_SPACE=preview)
+	$(eval export API_HOSTNAME=notify.works)
+	cf target -s ${CF_SPACE}
+
+.PHONY: staging
+staging:
+	$(eval export CF_SPACE=staging)
+	$(eval export API_HOSTNAME=staging-notify.works)
+	cf target -s ${CF_SPACE}
+
+.PHONY: generate-manifest
+generate-manifest:
+	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
+	@sed -e "s/{{CF_SPACE}}/${CF_SPACE}/; s/{{API_HOSTNAME}}/${API_HOSTNAME}/" manifest.yml.tpl
+
+.PHONY: cf-push
+cf-push:
+	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
+	cf push -f <(make -s generate-manifest)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: build
+build:
+	go build -o bin/sms-provider-stub
+
+run: build
+	./bin/sms-provider-stub

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # notifications-sms-provider-stub
-Stub API server for Notify SMS providers
+
+This is a simple Go server that can be used as a stub for Notify SMS providers during a load test or when running the application locally. It accepts the requests for a notification, prints the message contents, returns an HTTP response and after a short delay sends a callback to a pre-configured URL.
+
+Set up
+------
+
+You need a Go compiler to build the binary (`brew install go`).
+To build and run the server locally:
+
+```shell
+
+make run
+
+```
+
+This will start a server on port 6300, configured to send the callbacks to a local Notify API. To configure Notify API to use the server instead of actual MMG and Firetext set the `environment.sh` variables in the Notify API:
+
+```shell
+
+export MMG_URL='http://localhost:6300/mmg'
+export FIRETEXT_URL='http://localhost:6300/firetext'
+
+```
+
+Configuration
+-------------
+
+Server can be configured using environment variables:
+
+```shell
+
+export PORT=6300  # server port
+
+export MMG_MIN_DELAY_MS=100  # min delay before callback is sent in ms
+export MMG_MAX_DELAY_MS=1000 # max delay before callback is sent in ms
+export MMG_CALLBACK_URL='http://localhost:6011/notifications/sms/mmg'
+
+export FIRETEXT_MIN_DELAY_MS=100
+export FIRETEXT_MAX_DELAY_MS=1000
+export FIRETEXT_CALLBACK_URL='http://localhost:6011/notifications/sms/firetext'
+
+```

--- a/firetext.go
+++ b/firetext.go
@@ -21,16 +21,16 @@ type FiretextCallback struct {
 	Mobile    string `json:"mobile"`
 }
 
-var FIRETEXT_MIN_DELAY int
-var FIRETEXT_MAX_DELAY int
+var FIRETEXT_MIN_DELAY_MS int
+var FIRETEXT_MAX_DELAY_MS int
 var FIRETEXT_CALLBACK_URL string
 
 func init() {
-	FIRETEXT_MIN_DELAY, _ = strconv.Atoi(getenv("FIRETEXT_MIN_DELAY", "100"))
-	FIRETEXT_MAX_DELAY, _ = strconv.Atoi(getenv("FIRETEXT_MAX_DELAY", "1000"))
+	FIRETEXT_MIN_DELAY_MS, _ = strconv.Atoi(getenv("FIRETEXT_MIN_DELAY_MS", "100"))
+	FIRETEXT_MAX_DELAY_MS, _ = strconv.Atoi(getenv("FIRETEXT_MAX_DELAY_MS", "1000"))
 	FIRETEXT_CALLBACK_URL = getenv("FIRETEXT_CALLBACK_URL", "http://localhost:6011/notifications/sms/firetext")
 
-	log.Printf("Firetext callback: URL %s, with delay %d-%d ms\n", FIRETEXT_CALLBACK_URL, FIRETEXT_MIN_DELAY, FIRETEXT_MAX_DELAY)
+	log.Printf("Firetext callback: URL %s, with delay %d-%d ms\n", FIRETEXT_CALLBACK_URL, FIRETEXT_MIN_DELAY_MS, FIRETEXT_MAX_DELAY_MS)
 }
 
 func FiretextEndpoint(w http.ResponseWriter, r *http.Request) {
@@ -39,7 +39,7 @@ func FiretextEndpoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("Firetext received message %s:  %s  \n", r.FormValue("reference"), r.FormValue("message"))
+	log.Printf("Firetext received message %s:\n\n    %s\n\n", r.FormValue("reference"), r.FormValue("message"))
 
 	json.NewEncoder(w).Encode(FiretextResponse{Code: 0, Description: "SMS successfully queued"})
 	go FiretextSendCallback(r.FormValue("reference"), r.FormValue("to"))
@@ -47,7 +47,7 @@ func FiretextEndpoint(w http.ResponseWriter, r *http.Request) {
 
 func FiretextSendCallback(reference string, to string) {
 
-	time.Sleep(time.Duration(FIRETEXT_MIN_DELAY+rand.Intn(FIRETEXT_MAX_DELAY-FIRETEXT_MIN_DELAY)) * time.Millisecond)
+	time.Sleep(time.Duration(FIRETEXT_MIN_DELAY_MS+rand.Intn(FIRETEXT_MAX_DELAY_MS-FIRETEXT_MIN_DELAY_MS)) * time.Millisecond)
 
 	res, err := http.PostForm(FIRETEXT_CALLBACK_URL, url.Values{
 		"status":    {"0"},

--- a/firetext.go
+++ b/firetext.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+type FiretextResponse struct {
+	Description string `json:"description"`
+	Code        int    `json:"code"`
+}
+
+type FiretextCallback struct {
+	Status    string `json:"status"`
+	Reference string `json:"reference"`
+	Mobile    string `json:"mobile"`
+}
+
+var FIRETEXT_MIN_DELAY int
+var FIRETEXT_MAX_DELAY int
+var FIRETEXT_CALLBACK_URL string
+
+func init() {
+	FIRETEXT_MIN_DELAY, _ = strconv.Atoi(getenv("FIRETEXT_MIN_DELAY", "100"))
+	FIRETEXT_MAX_DELAY, _ = strconv.Atoi(getenv("FIRETEXT_MAX_DELAY", "1000"))
+	FIRETEXT_CALLBACK_URL = getenv("FIRETEXT_CALLBACK_URL", "http://localhost:6011/notifications/sms/firetext")
+
+	log.Printf("Firetext callback: URL %s, with delay %d-%d ms\n", FIRETEXT_CALLBACK_URL, FIRETEXT_MIN_DELAY, FIRETEXT_MAX_DELAY)
+}
+
+func FiretextEndpoint(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Firetext received message %s:  %s  \n", r.FormValue("reference"), r.FormValue("message"))
+
+	json.NewEncoder(w).Encode(FiretextResponse{Code: 0, Description: "SMS successfully queued"})
+	go FiretextSendCallback(r.FormValue("reference"), r.FormValue("to"))
+}
+
+func FiretextSendCallback(reference string, to string) {
+
+	time.Sleep(time.Duration(FIRETEXT_MIN_DELAY+rand.Intn(FIRETEXT_MAX_DELAY-FIRETEXT_MIN_DELAY)) * time.Millisecond)
+
+	res, err := http.PostForm(FIRETEXT_CALLBACK_URL, url.Values{
+		"status":    {"0"},
+		"reference": {reference},
+		"mobile":    {to},
+	})
+	if err != nil {
+		log.Printf("Firetext callback failed: %s\n", err.Error())
+		return
+	}
+
+	log.Printf("Firetext callback sent for %s: %s", reference, res.Status)
+}

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,9 @@
+---
+applications:
+- name: notify-sms-provider-stub
+  memory: 256M
+  instances: 1
+  buildpacks:
+    - go_buildpack
+  env:
+    GOPACKAGENAME: github.com/alphagov/notifications-sms-provider-stub

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,9 +1,0 @@
----
-applications:
-- name: notify-sms-provider-stub
-  memory: 256M
-  instances: 1
-  buildpacks:
-    - go_buildpack
-  env:
-    GOPACKAGENAME: github.com/alphagov/notifications-sms-provider-stub

--- a/manifest.yml.tpl
+++ b/manifest.yml.tpl
@@ -1,0 +1,18 @@
+---
+applications:
+- name: notify-sms-provider-stub
+
+  memory: 256M
+  instances: 1
+
+  buildpacks:
+    - go_buildpack
+
+  routes:
+    - route: notify-sms-provider-stub-{{CF_SPACE}}.cloudapps.digital
+
+  env:
+    GOVERSION: go1.12
+    GOPACKAGENAME: github.com/alphagov/notifications-sms-provider-stub
+    MMG_CALLBACK_URL: https://{{API_HOSTNAME}}/notifications/sms/mmg
+    FIRETEXT_CALLBACK_URL: https://{{API_HOSTNAME}}/notifications/sms/firetext

--- a/mmg.go
+++ b/mmg.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type MmgRequest struct {
+	ReqType string `json:"reqType"`
+	MSISDN  string
+	Msg     string `json:"msg"`
+	Sender  string `json:"sender"`
+	Cid     string `json:"cid"`
+	Multi   bool   `json:"multi"`
+}
+
+type MmgResponse struct {
+	Reference int
+}
+
+type MmgCallback struct {
+	Status string `json:"status"`
+	Cid    string `json:"CID"`
+	MSISDN string
+}
+
+var MMG_MIN_DELAY int
+var MMG_MAX_DELAY int
+var MMG_CALLBACK_URL string
+
+func init() {
+	MMG_MIN_DELAY, _ = strconv.Atoi(getenv("MMG_MIN_DELAY", "100"))
+	MMG_MAX_DELAY, _ = strconv.Atoi(getenv("MMG_MAX_DELAY", "1000"))
+	MMG_CALLBACK_URL = getenv("MMG_CALLBACK_URL", "http://localhost:6011/notifications/sms/mmg")
+
+	log.Printf("MMG callback: URL %s, with delay %d-%d ms\n", MMG_CALLBACK_URL, MMG_MIN_DELAY, MMG_MAX_DELAY)
+}
+
+func MmgEndpoint(w http.ResponseWriter, r *http.Request) {
+	var reqData MmgRequest
+	if err := json.NewDecoder(r.Body).Decode(&reqData); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("MMG received message %s:  %s  \n", reqData.Cid, reqData.Msg)
+
+	json.NewEncoder(w).Encode(MmgResponse{Reference: rand.Intn(100000)})
+	go MmgSendCallback(reqData.Cid, reqData.MSISDN)
+}
+
+func MmgSendCallback(cid string, msisdn string) {
+
+	time.Sleep(time.Duration(MMG_MIN_DELAY+rand.Intn(MMG_MAX_DELAY-MMG_MIN_DELAY)) * time.Millisecond)
+
+	data := MmgCallback{Cid: cid, Status: "3", MSISDN: msisdn}
+	buf := new(bytes.Buffer)
+	json.NewEncoder(buf).Encode(data)
+
+	res, err := http.Post(MMG_CALLBACK_URL, "application/json; charset=utf-8", buf)
+	if err != nil {
+		log.Printf("MMG callback failed: %s\n", err.Error())
+		return
+	}
+
+	log.Printf("MMG callback sent for %s: %s", cid, res.Status)
+}

--- a/mmg.go
+++ b/mmg.go
@@ -29,16 +29,16 @@ type MmgCallback struct {
 	MSISDN string
 }
 
-var MMG_MIN_DELAY int
-var MMG_MAX_DELAY int
+var MMG_MIN_DELAY_MS int
+var MMG_MAX_DELAY_MS int
 var MMG_CALLBACK_URL string
 
 func init() {
-	MMG_MIN_DELAY, _ = strconv.Atoi(getenv("MMG_MIN_DELAY", "100"))
-	MMG_MAX_DELAY, _ = strconv.Atoi(getenv("MMG_MAX_DELAY", "1000"))
+	MMG_MIN_DELAY_MS, _ = strconv.Atoi(getenv("MMG_MIN_DELAY_MS", "100"))
+	MMG_MAX_DELAY_MS, _ = strconv.Atoi(getenv("MMG_MAX_DELAY_MS", "1000"))
 	MMG_CALLBACK_URL = getenv("MMG_CALLBACK_URL", "http://localhost:6011/notifications/sms/mmg")
 
-	log.Printf("MMG callback: URL %s, with delay %d-%d ms\n", MMG_CALLBACK_URL, MMG_MIN_DELAY, MMG_MAX_DELAY)
+	log.Printf("MMG callback: URL %s, with delay %d-%d ms\n", MMG_CALLBACK_URL, MMG_MIN_DELAY_MS, MMG_MAX_DELAY_MS)
 }
 
 func MmgEndpoint(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +48,7 @@ func MmgEndpoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("MMG received message %s:  %s  \n", reqData.Cid, reqData.Msg)
+	log.Printf("MMG received message %s:\n\n    %s\n\n", reqData.Cid, reqData.Msg)
 
 	json.NewEncoder(w).Encode(MmgResponse{Reference: rand.Intn(100000)})
 	go MmgSendCallback(reqData.Cid, reqData.MSISDN)
@@ -56,7 +56,7 @@ func MmgEndpoint(w http.ResponseWriter, r *http.Request) {
 
 func MmgSendCallback(cid string, msisdn string) {
 
-	time.Sleep(time.Duration(MMG_MIN_DELAY+rand.Intn(MMG_MAX_DELAY-MMG_MIN_DELAY)) * time.Millisecond)
+	time.Sleep(time.Duration(MMG_MIN_DELAY_MS+rand.Intn(MMG_MAX_DELAY_MS-MMG_MIN_DELAY_MS)) * time.Millisecond)
 
 	data := MmgCallback{Cid: cid, Status: "3", MSISDN: msisdn}
 	buf := new(bytes.Buffer)

--- a/server.go
+++ b/server.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/mmg", MmgEndpoint)
+	http.HandleFunc("/firetext", FiretextEndpoint)
+	port := getenv("PORT", "6300")
+	log.Printf("Listening on port %s...\n", port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,11 @@
+package main
+
+import "os"
+
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}


### PR DESCRIPTION
This is a simple Go server that can be used as a stub for Notify SMS providers during a load test or when running the application locally. It accepts the requests for a notification, prints the message contents, returns an HTTP response and after a short delay sends a callback to a pre-configured URL.

This is written in Go beacause:

a) Go's concurrency model makes the callbacks with delay really simple to implement
b) there are no dependencies and it's very easy to distribute either as source or as a compiled binary
c) it's fast enough so we shouldn't have to worry about it being a bottleneck
d) this is small enough so it doesn't really matter

A quick load test on a single 256MB PaaS instance (according to Prometheus it was using ~50% CPU and 15MB of RAM), and 600 RPS is our overall target for the Notify load test, only 10% of that will go through SMS providers:

```
Summary:
  Total:	180.0382 secs
  Slowest:	1.0537 secs
  Fastest:	0.0152 secs
  Average:	0.0332 secs
  Requests/sec:	601.6725

  Total data:	2154301 bytes
  Size/request:	19 bytes

Response time histogram:
  0.015 [1]	|
  0.119 [107569]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.223 [673]	|
  0.327 [61]	|
  0.431 [6]	|
  0.534 [1]	|
  0.638 [8]	|
  0.742 [2]	|
  0.846 [0]	|
  0.950 [0]	|
  1.054 [3]	|


Latency distribution:
  10% in 0.0210 secs
  25% in 0.0239 secs
  50% in 0.0286 secs
  75% in 0.0362 secs
  90% in 0.0486 secs
  95% in 0.0612 secs
  99% in 0.1082 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0152 secs, 1.0537 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0216 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0021 secs
  resp wait:	0.0330 secs, 0.0151 secs, 1.0536 secs
  resp read:	0.0001 secs, 0.0000 secs, 0.0055 secs

Status code distribution:
  [200]	108324 responses
```