### PR TITLE
Host stub app on an internal route

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ export FIRETEXT_URL='http://localhost:6300/firetext'
 To turn it on for an app running in the PaaS use:
 
 ```
-cf set-env APP-NAME FIRETEXT_URL https://notify-sms-provider-stub-staging.cloudapps.digital/firetext
+cf set-env APP-NAME FIRETEXT_URL http://notify-sms-provider-stub-staging.apps.internal:8080/firetext
 cf restage APP-NAME
 ```
 

--- a/manifest.yml.tpl
+++ b/manifest.yml.tpl
@@ -10,6 +10,7 @@ applications:
 
   routes:
     - route: notify-sms-provider-stub-{{CF_SPACE}}.cloudapps.digital
+    - route: notify-sms-provider-stub-{{CF_SPACE}}.apps.internal
 
   env:
     GOVERSION: go1.16


### PR DESCRIPTION
Under load test conditions, traffic to public routes is sent via the PaaS gorouter. This causes traffic to be amplified within the platform which does not accurately reflect production conditions.

We can use an internal route which sends traffic directly the the app via the internal hostname. Ideally this app should be hosted outside of the isolation segment or PaaS to simulate real-world remote network conditions - this can be addressed at a later point.

See: https://docs.cloud.service.gov.uk/deploying_apps.html#deploying-private-apps