### PR TITLE
Double the memory from 256M to 512M

### DIFF
--- a/manifest.yml.tpl
+++ b/manifest.yml.tpl
@@ -2,7 +2,7 @@
 applications:
 - name: notify-sms-provider-stub
 
-  memory: 256M
+  memory: 512M
   instances: 1
 
   buildpacks:


### PR DESCRIPTION
In one of the loadtests we forgot to scale this stub and it fell over
because it ran out of memory.

One assumption is that it creates too many coroutines as part of the
callbacks and 256M are not enough [[link](https://stackoverflow.com/a/31496043)]

A better approach would be to limit the number of coroutines we can
spawn, so that we don't get run into this situation, e.g. using
semaphores [[link](http://jmoiron.net/blog/limiting-concurrency-in-go/)]