### PR TITLE
Add boilerplate for testing Reach SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ export MMG_MIN_DELAY_MS=100  # min delay before callback is sent in ms
 export MMG_MAX_DELAY_MS=1000 # max delay before callback is sent in ms
 export MMG_CALLBACK_URL='http://localhost:6011/notifications/sms/mmg'
 
-export FIRETEXT_MIN_DELAY_MS=100
-export FIRETEXT_MAX_DELAY_MS=1000
-export FIRETEXT_CALLBACK_URL='http://localhost:6011/notifications/sms/firetext'
+# similarly for each other provider
 "> environment.sh
 ```
 
@@ -37,10 +35,9 @@ make run
 This will start a server on port 6300, configured to send the callbacks to a local Notify API. To configure Notify API to use the server instead of actual MMG and Firetext set the `environment.sh` variables in the Notify API:
 
 ```shell
-
 export MMG_URL='http://localhost:6300/mmg'
-export FIRETEXT_URL='http://localhost:6300/firetext'
 
+# similarly for each other provider
 ```
 
 ## To deploy the application
@@ -54,4 +51,4 @@ cf set-env APP-NAME FIRETEXT_URL http://notify-sms-provider-stub-staging.apps.in
 cf restage APP-NAME
 ```
 
-and equivalent for the `MMG_URL`. The environment variables will remain set even if you redeploy the app.
+and equivalent for other providers. The environment variables will remain set even if you redeploy the app.

--- a/reach.go
+++ b/reach.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+  "encoding/json"
+	"log"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+type ReachResponse struct {
+  // TODO
+}
+
+//type ReachCallback struct {
+	//Status    string `json:"status"`
+	//Reference string `json:"reference"`
+	//Mobile    string `json:"mobile"`
+//}
+
+var REACH_MIN_DELAY_MS int
+var REACH_MAX_DELAY_MS int
+var REACH_CALLBACK_URL string
+var reachClient *http.Client
+
+func init() {
+	REACH_MIN_DELAY_MS, _ = strconv.Atoi(getenv("REACH_MIN_DELAY_MS", "100"))
+	REACH_MAX_DELAY_MS, _ = strconv.Atoi(getenv("REACH_MAX_DELAY_MS", "1000"))
+	REACH_CALLBACK_URL = getenv("REACH_CALLBACK_URL", "http://localhost:6011/notifications/sms/reach")
+	var maxConns, _ = strconv.Atoi(getenv("REACH_MAX_CONNS", "256"))
+
+	log.Printf("Reach callback: URL %s, with delay %d-%d ms\n", REACH_CALLBACK_URL, REACH_MIN_DELAY_MS, REACH_MAX_DELAY_MS)
+
+	reachClient = &http.Client{
+		Timeout: time.Second * 10,
+		Transport: &http.Transport{
+			MaxConnsPerHost: maxConns,
+		},
+	}
+}
+
+func ReachEndpoint(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Reach received message TODO")
+
+  json.NewEncoder(w).Encode(ReachResponse{})
+	//go ReachSendCallback(r.FormValue("reference"), r.FormValue("to"))
+}
+
+func ReachSendCallback(reference string, to string) {
+
+	time.Sleep(time.Duration(REACH_MIN_DELAY_MS+rand.Intn(REACH_MAX_DELAY_MS-REACH_MIN_DELAY_MS)) * time.Millisecond)
+
+	res, err := reachClient.PostForm(REACH_CALLBACK_URL, url.Values{
+    // TODO
+  })
+	if err != nil {
+		log.Printf("Reach callback failed: %s\n", err.Error())
+		return
+	}
+	res.Body.Close()
+
+	log.Printf("Reach callback sent for %s: %s", reference, res.Status)
+}

--- a/server.go
+++ b/server.go
@@ -8,6 +8,7 @@ import (
 func main() {
 	http.HandleFunc("/mmg", MmgEndpoint)
 	http.HandleFunc("/firetext", FiretextEndpoint)
+	http.HandleFunc("/reach", ReachEndpoint)
 	port := getenv("PORT", "6300")
 	log.Printf("Listening on port %s...\n", port)
 	log.Fatal(http.ListenAndServe(":"+port, nil))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181574489

This makes it possible to send empty SMS requests from API and have
them responded to with a 200. Until we have the API spec from Reach
there's no point adding in callback behaviour as this can be tested
manually without the stub [^1].

[^1]: https://github.com/alphagov/notifications-api/pull/3492