### PR TITLE
Use internal paas networking for staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
 CF_MANIFEST_PATH ?= /tmp/manifest.yml
+API_PROTOCOL ?= https
 
 .PHONY: build
 build:
@@ -18,13 +19,14 @@ preview:
 .PHONY: staging
 staging:
 	$(eval export CF_SPACE=staging)
-	$(eval export API_HOSTNAME=api.staging-notify.works)
+	$(eval export API_HOSTNAME=notify-api-staging.apps.internal:8080)
+	$(eval export API_PROTOCOL=http)
 	cf target -s ${CF_SPACE}
 
 .PHONY: generate-manifest
 generate-manifest:
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
-	@sed -e "s/{{CF_SPACE}}/${CF_SPACE}/; s/{{API_HOSTNAME}}/${API_HOSTNAME}/" manifest.yml.tpl
+	@sed -e "s/{{CF_SPACE}}/${CF_SPACE}/; s/{{API_HOSTNAME}}/${API_HOSTNAME}/; s/{{API_PROTOCOL}}/${API_PROTOCOL}/" manifest.yml.tpl
 
 .PHONY: cf-push
 cf-push:

--- a/manifest.yml.tpl
+++ b/manifest.yml.tpl
@@ -14,5 +14,5 @@ applications:
 
   env:
     GOVERSION: go1.19
-    MMG_CALLBACK_URL: https://{{API_HOSTNAME}}/notifications/sms/mmg
-    FIRETEXT_CALLBACK_URL: https://{{API_HOSTNAME}}/notifications/sms/firetext
+    MMG_CALLBACK_URL: {{API_PROTOCOL}}://{{API_HOSTNAME}}/notifications/sms/mmg
+    FIRETEXT_CALLBACK_URL: {{API_PROTOCOL}}://{{API_HOSTNAME}}/notifications/sms/firetext


### PR DESCRIPTION
When running load tests recently, I noticed an unusual distribution of requests from here to the API: 90% of the requests were being sent to only a few of the API instances, causing uneven load that led to the load test results being somewhat inconsistent/unreliable.

We aren't exactly sure why this has been happening, but switching over to using an internal route for the API has alleviated the problem and left us with a clean distribution of requests across all API instances.

## Before change
<img width="1179" alt="image" src="https://github.com/alphagov/notifications-sms-provider-stub/assets/2920760/85a03e35-161f-4b05-9bc5-a15642544383">

## After change
<img width="1173" alt="image" src="https://github.com/alphagov/notifications-sms-provider-stub/assets/2920760/b5f11c90-da51-449c-b3ff-873eecd7ff84">
