### PR TITLE
Switch to use cflinuxfs4 stack on the paas

### DIFF
--- a/manifest.yml.tpl
+++ b/manifest.yml.tpl
@@ -8,6 +8,8 @@ applications:
   buildpacks:
     - go_buildpack
 
+  stack: cflinuxfs4
+
   routes:
     - route: notify-sms-provider-stub-{{CF_SPACE}}.cloudapps.digital
     - route: notify-sms-provider-stub-{{CF_SPACE}}.apps.internal


### PR DESCRIPTION
What
----

Switch to use the PaaS cflinuxfs4 stack.

Why
----

cflinuxfs3 is currently the default on the PaaS. This is based off ubuntu 18.04. This stopped receiving updates after Apr 2023.

cflinuxfs4 will become the default on the PaaS after 27 Nov 2023.

The intention is to migrate all applications to cflinuxfs4 eventually.