### PR TITLE
Update clients to optionally pass through the ECS header

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ export MMG_CALLBACK_URL='http://localhost:6011/notifications/sms/mmg'
 "> environment.sh
 ```
 
+To target the ECS apps by setting the ECS header, you can give the `USE_ECS_APPS` environment variable a value of "true":
+```shell
+export USE_ECS_APPS="true"
+```
+
 ## To run the application
 
 To build and run the server locally:

--- a/firetext.go
+++ b/firetext.go
@@ -6,7 +6,9 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -58,11 +60,24 @@ func FiretextSendCallback(reference string, to string) {
 
 	time.Sleep(time.Duration(FIRETEXT_MIN_DELAY_MS+rand.Intn(FIRETEXT_MAX_DELAY_MS-FIRETEXT_MIN_DELAY_MS)) * time.Millisecond)
 
-	res, err := firetextClient.PostForm(FIRETEXT_CALLBACK_URL, url.Values{
+	data := url.Values{
 		"status":    {"0"},
 		"reference": {reference},
 		"mobile":    {to},
-	})
+	}
+	formDataReader := strings.NewReader(data.Encode())
+
+	req, err := http.NewRequest("POST", FIRETEXT_CALLBACK_URL, formDataReader)
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	ecs_header := os.Getenv("USE_ECS_APPS")
+	if ecs_header == "true" {
+		req.Header.Set("x-notify-ecs-origin", "true")
+	}
+
+	res, err := firetextClient.Do(req)
+
 	if err != nil {
 		log.Printf("Firetext callback failed: %s\n", err.Error())
 		return

--- a/mmg.go
+++ b/mmg.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 )
@@ -71,7 +72,17 @@ func MmgSendCallback(cid string, msisdn string) {
 	buf := new(bytes.Buffer)
 	json.NewEncoder(buf).Encode(data)
 
-	res, err := mmgClient.Post(MMG_CALLBACK_URL, "application/json; charset=utf-8", buf)
+	req, err := http.NewRequest("POST", MMG_CALLBACK_URL, buf)
+
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	ecs_header := os.Getenv("USE_ECS_APPS")
+	if ecs_header == "true" {
+		req.Header.Set("x-notify-ecs-origin", "true")
+	}
+
+	res, err := mmgClient.Do(req)
+
 	if err != nil {
 		log.Printf("MMG callback failed: %s\n", err.Error())
 		return


### PR DESCRIPTION
We want both SMS clients to be able to pass through the ECS header ("x-notify-ecs-origin") so that they can be used to stub requests from the ECS apps.

This change passes the header through if the `USE_ECS_APPS` environment variable has a value of `"true"`. If the variable is not set or has any other value the header will not be passed.

Passing the header means that we need to change the client methods that are used to allow this.