### PR TITLE
Switch to debian bookworm for sms stub provider

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.21.3-bullseye as builder
+FROM golang:1.21.3-bookworm as builder
 WORKDIR /src
 
 COPY go.mod .
@@ -9,6 +9,7 @@ COPY *.go .
 ARG CGO_ENABLED=0
 RUN go build -o /bin/sms-provider-stub .
 
-FROM scratch
+FROM debian:bookworm
 COPY --from=builder /bin/sms-provider-stub /bin/sms-provider-stub
+RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/*
 CMD ["/bin/sms-provider-stub"]


### PR DESCRIPTION
What
----

Switch to debian bookworm for sms stub provider

Why
----

The scratch image is missing a shell and ca certificates.